### PR TITLE
Introduce new Long Term Support (LTS) policy

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -55,10 +55,10 @@
     - [Interpreting Scan Alerts](faq/faq-scan-alerts.md)
     - [Upgrading](faq/faq-upgrade.md)
     - [Win32](faq/faq-win32.md)
-    - [ClamAV EOL Policy](faq/faq-eol.md)
     - [PUA (Potentially Unwanted Application)](faq/faq-pua.md)
     - [Ignore](faq/faq-ignore.md)
     - [Uninstall](faq/faq-uninstall.md)
+    - [ClamAV EOL Policy](faq/faq-eol.md)
 
 -----------
 

--- a/src/faq/faq-eol.md
+++ b/src/faq/faq-eol.md
@@ -32,7 +32,7 @@ Non-LTS feature releases will be allowed access to download signatures until at 
 
 - *"patch version"* -- A specific MAJOR.MINOR.PATCH version.
 
-  For example: 0.103.4 would be the next "patch version" in the 0.103 "feature release".
+  For example: 0.103.3 is a "patch version" in the 0.103 "feature release".
 
 - *"end of life" (EOL)* -- The date after which the ClamAV Team will no longer support a feature version in any way.
 
@@ -40,11 +40,11 @@ Non-LTS feature releases will be allowed access to download signatures until at 
 
 - *"long term support (LTS) release"* -- A feature release that will get critical patch versions for an extended period.
 
-  The latest patch version will continue to get access to download signature databases for the duration of the support period.
+  The latest patch version will continue to get access to download signature databases for the duration of the support period. See [above](#long-term-support-lts-feature-releases) for policy details.
 
 - *"regular (non-LTS) release"* -- A feature release that will only be supported until a little after the next feature release.
 
-  The latest patch version will continue to get access to download signature databases a little longer than that, but users are encouraged to upgrade and may be vulnerable if a security patch is only published for the next feature release and they fail to upgrade.
+  The latest patch version will continue to get access to download signature databases a little longer than that, but users are encouraged to upgrade and may be vulnerable if a security patch is only published for the next feature release and they fail to upgrade. See [above](#regular-non-lts-feature-releases) for policy details.
 
 - *"support"* -- The ClamAV project defines "support" in several ways:
 
@@ -85,7 +85,7 @@ Non-LTS feature releases will be allowed access to download signatures until at 
 | 0.102           | Oct 2019             | 0.102.4              | Dec 2021 (0.104 + 4 mo.)   | Dec 2021                     |                            | Dec 2021                   |                               |
 | 0.101           | Dec 2018             | 0.101.5              | Dec 2021                   | Dec 2021                     |                            | Dec 2021                   |                               |
 | 0.100           | Mar 2018             | 0.100.3              | Oct-29 2021                | Oct-29 2021                  |                            | Oct-29 2021                |                               |
-| 0.99(.2)        | May 2016             | 0.99.4               | Mar-1 2021                 |                              |                            |                            |                               |
+| 0.99            | Dec 2015             | 0.99.4               | Mar-1 2021                 |                              |                            |                            |                               |
 
 Currently, every version from ClamAV 0.99 and down, including all patch versions, are unsupported, and **are actively blocked from downloading new updates**.
 

--- a/src/faq/faq-eol.md
+++ b/src/faq/faq-eol.md
@@ -1,39 +1,131 @@
-# End of Life Policy (EOL)
+# End of Life (EOL) Policy
 
-The naming convention for ClamAV releases uses three numbers (X.Y.Z) where the first two (X.Y) identify a feature release and the last one (Z) a patch version.
+This document describes the End of Life (EOL) policy for Long Term Support (LTS) feature releases and for regular (non-LTS) feature releases.
 
-As of July, 2021, the latest feature release is 0.103 and the latest patch version is 0.103.3.
+Skip to our [Version Support Matrix](#version-support-matrix) to quickly check if your version is still supported.
 
-## ClamAV Versions Supported by the Official Signature Databases
+> _Disclaimer_: If this policy has to change due to a compatibility problem that prohibits the use of new detection technology, or impacts the stability of ClamAV infrastructure, we will announce the end of life for those versions four months before they become unsupported.
 
-Before releasing a signature database (CVD) update, we verify that it can be correctly loaded by the latest two feature releases of ClamAV and all the patch versions released after each of them.
+## Long Term Support (LTS) Feature Releases
 
-We only check the CVD update for false positives using the latest patch release (or feature release, in case there has been no patch release after the last feature release).
+ClamAV ***0.103*** is the first Long Term Support (LTS) feature release.
 
-**Disclaimer**: if this policy has to change due to a compatibility problem that prohibits the use of new detection technology, or impacts the stability of ClamAV infrastructure, we will announce the end of life for those versions four months before they become unsupported.
+LTS feature releases will be supported for *at least* **three (3)** years from the initial publication date of that LTS feature version. In other words, support for the LTS release "X.Y" starts when version "X.Y.0" is published and ends three years after.
+
+Each LTS feature release will be supported with critical patch versions *and* access to download signatures for the duration of the three year support period.
+
+A new LTS feature release will be identified *approximately* every **two (2)** years.
+
+*Users must stay up-to-date with the latest patch versions for continued support. As of August 28, that means version 0.103.3.*
+
+## Regular (non-LTS) Feature Releases
+
+Non-LTS feature releases will be supported with critical patch versions for *at least* **four (4) months** from the initial publication date of the ***next*** feature release or until the *next*-***next*** feature release is published.
+
+Non-LTS feature releases will be allowed access to download signatures until at least four (4) months after the *next*-***next*** feature release is published.
+
+## Definitions
+
+- *"feature release"* -- A version starting with MAJOR.MINOR.0 to include all PATCH versions.
+
+  For example: ClamAV 0.103.0, 0.103.1, 0.103.2, and 0.103.3 are all "patch versions" within the same "feature release".
+
+- *"patch version"* -- A specific MAJOR.MINOR.PATCH version.
+
+  For example: 0.103.4 would be the next "patch version" in the 0.103 "feature release".
+
+- *"end of life" (EOL)* -- The date after which the ClamAV Team will no longer support a feature version in any way.
+
+  After this point, all patch versions of that release may be blocked from downloading official signature content.
+
+- *"long term support (LTS) release"* -- A feature release that will get critical patch versions for an extended period.
+
+  The latest patch version will continue to get access to download signature databases for the duration of the support period.
+
+- *"regular (non-LTS) release"* -- A feature release that will only be supported until a little after the next feature release.
+
+  The latest patch version will continue to get access to download signature databases a little longer than that, but users are encouraged to upgrade and may be vulnerable if a security patch is only published for the next feature release and they fail to upgrade.
+
+- *"support"* -- The ClamAV project defines "support" in several ways:
+
+  1. *Critical patch support*:
+
+     The ClamAV Team provides critical patch versions for supported feature releases([**](#additional-detail-about-critical-patch-support)).
+
+     The Application Binary Interface (ABI) shall not change between patch versions within a given feature release. That is, the SONAMEs for the ClamAV libraries will remain the same and changes in a patch version will not break compatibility with older library versions.
+
+     Users are responsible for updating to the latest patch version for continued support.
+
+  2. *Signature Database (CVD) Access*:
+
+     Supported releases are allowed free access to download the latest signature databases.
+
+     Users must keep up-to-date with the latest patch version to maintain access to the official signature database content.
+
+     We reserve the right to block older/problematic patch versions 4 months after the release of a newer patch version.
+
+  3. *New-Signature Load/Functional Testing*:
+
+     The ClamAV Team will load-test new sigantures for functional correctness on **all versions** that are allowed access to download the official signature databases.
+
+  4. *New-Signature False Positive Testing*:
+
+     The ClamAV Team will perform false positive testing for new signature content, but only using the latest patch version of the latest feature release. False positive testing requires scanning large data sets. It is more time consuming than functional testing.
+
+  Cisco does not offer paid technical support or paid extended long term support for ClamAV.
+
+## Version Support Matrix
+
+> _Note_: This markdown table is generated from a spreadsheet using [this tool](https://thisdavej.com/copy-table-in-excel-and-paste-as-a-markdown-table/).
+
+| Feature release | First Published      | Latest patch version | Expected End of Life (EOL) | Signature load testing until | Signature FP testing until | DB downloads allowed until | Patch versions continue until |
+| --------------- | -------------------- | -------------------- | -------------------------- | ---------------------------- | -------------------------- | -------------------------- | ----------------------------- |
+| 0.104           | expected Aug-31 2021 | 0.104.0              | 0.106 + 4 months           | 0.106 + 4 months             |                            | 0.106 + 4 months           | 0.105 + 4 months, or 0.106    |
+| **0.103 LTS**   | **Sep 2020**         | **0.103.3**          | **Sep 2023**               | **Sep 2023**                 | 0.104 published            | **Sep 2023**               | **Sep 2023**                  |
+| 0.102           | Oct 2019             | 0.102.4              | Dec 2021 (0.104 + 4 mo.)   | Dec 2021                     |                            | Dec 2021                   |                               |
+| 0.101           | Dec 2018             | 0.101.5              | Dec 2021                   | Dec 2021                     |                            | Dec 2021                   |                               |
+| 0.100           | Mar 2018             | 0.100.3              | Oct-29 2021                | Oct-29 2021                  |                            | Oct-29 2021                |                               |
+| 0.99(.2)        | May 2016             | 0.99.4               | Mar-1 2021                 |                              |                            |                            |                               |
 
 Currently, every version from ClamAV 0.99 and down, including all patch versions, are unsupported, and **are actively blocked from downloading new updates**.
 
-## ClamAV Versions Receiving Back-ported Security Patches
+## Additional Detail About Critical Patch Support
 
-Like all bugs, security patches are prepared for our upcoming feature release. Only security patches and other critical fixes or critical improvements are backported to previous feature releases. The ClamAV team is small and can't afford to port fixes back very far. To keep momentum making progress on new features, improvements, and minor bug fixes, our policy is to backport no further than 1 or 2 feature releases.
+Like all bugs, security patches are first prepared for our upcoming feature release. Only security patches and other critical fixes or critical improvements are backported to previous feature releases.
 
-Our team also feels strongly that as a security product, newer ClamAV versions offer improved malware detection efficacy and that it is important for users to upgrade to newer ClamAV versions even on older long-term-support (LTS) Linux distributions. We ask that package maintainers make every effort to upgrade packages to newer ClamAV versions during the lifetime of an LTS distribution, unless you have reason to believe that upgrading users to the new ClamAV version would break things for your users.
+The ClamAV Team is small and can't afford to publish patch versions for every release. To keep up momentum crafting new features and other improvements, our policy is to backport no further than 1 or 2 of the latest feature releases plus the Long Term Support (LTS) feature releases.
 
-### Situation 1: Security Patches Less than 6 Months After a Feature Release
-
-If the non-disclosure / release date for a security patch falls within 6 months since the previous feature release was published, we will craft a security patch version for the future feature release, the current feature release, and the previous feature release.
-
-As an example, let's say ClamAV 0.102.0 was just released and development begins on 0.103. But shortly after the release or as we're preparing for the release, it is discovered that 0.102.0 contains one or more security issues. We understand with such a recent release, not everyone has had time to verify that they can indeed upgrade without some other supporting changes to their system or product. In this situation, we would prepare a security patch version for the 0.102 feature version (eg. 0.102.1) and for the 0.101 feature version (eg. 0.101.5). Once both releases have been published, the same or equivalent fixes will be merged into the `main` branch for inclusion into the next feature release (0.103.0).
-
-### Situation 2: Security Patches After a Breaking Change
+### Critical Patches After a Breaking Change
 
 On rare occasion we have made breaking changes to the way that users or other software interact with ClamAV or libclamav. The 0.101.0 release was one such example where we made a breaking change to the libclamav programming API. When this happens, we will provide extra time for users to upgrade to a newer feature release before we discontinue support for the older feature release.
 
 The amount of extra time before we discontinue support will vary depending on the severity of the breaking change and the level of difficulty to upgrade.
 
-### Situation 3: Security Patches More than 6 Months After a Feature Release Has Been Available
+### Examples
 
-If the non-disclosure / release date for a security patch falls after 6 months since the previous feature release was published, we will only craft a security patch version for the future feature release and the current feature release.
+#### Security Patches Less than four (4) Months After a Feature Release
 
-For example, if 0.102.0 was released in January and a security issue was found in May, but the non-disclosure agreement allowed for the bug to be patched after the standard 90 days, then a security patch release will likely be prepared for release in early August. This would exceed our 6-month policy, so we would publish the fix in 0.102.1 but would not publish a patch version for the 0.101 series.
+If the non-disclosure / release date for a security patch falls within four (4) months since the previous feature release was published, we will craft a security patch version for the future feature release, the current feature release, the previous feature release, and any LTS feature releases.
+
+> *Example*: Let's say ClamAV 0.105.0 was just released and development begins on 0.106. But shortly after the release or as we're preparing for the release, it is discovered that 0.105.0 contains one or more security issues.
+>
+> We understand with such a recent release, not everyone has had time to verify that they can indeed upgrade without some other supporting changes to their system or product.
+>
+> In this situation, we would prepare a security patch version for:
+> - the 0.105 feature release (eg. 0.105.1),
+> - for the 0.104 feature release (eg. 0.104.3),
+> - and for the 0.103 LTS feature release.
+>
+> Once the critical patch versions have been published, the same or equivalent fixes will be merged into the `main` branch for inclusion into the next feature release (0.106.0).
+
+#### Security Patches More than four (4) Months After a Feature Release Has Been Available
+
+If the non-disclosure / release date for a security patch falls after four (4) months since the previous feature release was published, we will only craft a security patch version for the future feature release, the current feature release, and any LTS feature releases.
+
+> *Example*: If 0.105.0 was released in January and a security issue was found in March, but the non-disclosure agreement allowed for the bug to be patched after the standard 90 days, then a security patch release will likely be prepared for release in early June.
+>
+> This would exceed our 4-month policy, so we would publish the fix:
+> - in 0.105 (eg. 0.105.1),
+> - and in 0.103 LTS, ...
+>
+> ... but would not publish a patch version for the 0.104 feature release.


### PR DESCRIPTION
Also adjustments to the existing End of Life (EOL) policy.

The new policy is:

- Non-LTS feature releases will be supported with critical patch
  versions for *at least* **four (4) months** from the initial
  publication date of the ***next*** feature release or until the
  *next*-***next*** feature release is published.

- Non-LTS feature releases will be allowed access to download
  signatures until at least four (4) months after the *next*-
  ***next*** feature release is published.

The EOL when the next-next feature release is published was previously
implied, and is now explicit.

But this is a reduction from 6 months to 4 months to match the number
of months in the CVD download access policy so as to reduce confusion.

The ClamAV team intends to increase feature release cadence and
so the effective number of supported versions, given the EOL after a
next-next release, should be the same.