### PR TITLE
Small Typo

### DIFF
--- a/src/manual/Usage/Scanning.md
+++ b/src/manual/Usage/Scanning.md
@@ -207,7 +207,7 @@ Run this to scan ALL the files on your system, it will take **quite** a while. K
 Linux/Unix:
 
 ```bash
-clamscan.exe --recursive /
+clamscan --recursive /
 ```
 
 Windows:


### PR DESCRIPTION
Linux/macOS should run clamscan without exe