### PR TITLE
mjbroekman - added tip to 'Running ClamD' section about setting port forwarding

### DIFF
--- a/src/manual/Installing/Docker.md
+++ b/src/manual/Installing/Docker.md
@@ -87,6 +87,8 @@ The above creates an interactive container with the current TTY connected to it.
 
 > _Tip_: It's common to see `-it` instead of `--interactive --tty`.
 
+> _Tip_: It's common to also publish (forward) the ClamAV TCP port to the local host to use the [TCP socket](#tcp) using `--publish 3310:3310` in the `docker run` command
+
 ### Running ClamD using a Locally Built Image
 
 You can run a container using an image built locally ([see "Building the ClamAV Image"](#building-the-clamav-image)). Just run:


### PR DESCRIPTION
The main information about using the TCP Socket in the docker image is far down the page from where the first run command is. I've added a tip about publishing the port and a link to the TCP section in that top section