### PR TITLE
Add step for freshclam configuration for SELinux users

### DIFF
--- a/src/manual/Usage/Configuration.md
+++ b/src/manual/Usage/Configuration.md
@@ -117,6 +117,8 @@ chmod 600 /var/log/freshclam.log
 chown clamav /var/log/freshclam.log
 ```
 
+>  _Tip_: If SELinux is enabled you probably need to set the right SELinux context on this newly created file, otherwise freshclam service won't be able to access this file. On Redhat-like systems, you should do `restorecon /var/log/freshclam.log`.
+
 Now you *should* edit the configuration file `freshclam.conf` and point the *UpdateLogFile* directive to the log file. Finally, to run `freshclam` in the daemon mode, execute:
 
 ```bash


### PR DESCRIPTION
Dear maintainer,
If freshclam service is configured on an OS with SELinux enabled, the manually created file `/var/log/freshclam.log` does not have the right SELinux context. This means the freshclam service is unable to log to the created log file.
I think the documentation can specify this subtlety and how to solve it.
Regards