### PR TITLE
document YARA hex negation support

### DIFF
--- a/src/manual/Signatures/BodySignatureFormat.md
+++ b/src/manual/Signatures/BodySignatureFormat.md
@@ -108,3 +108,53 @@ ClamAV supports the following character classes for hex-signatures:
   - Ranged wildcards (eg: `{n-m}`) are limited to a fixed range of less than 128 bytes (eg: `{1} -> {127}`).
 
 > _Note_: Using signature modifiers and wildcards classifies the alternate type to be a generic alternate. Thus single-byte alternates and multi-byte fixed length alternates can use signature modifiers and wildcards but will be classified as generic alternate. This means that negation cannot be applied in this situation and there is a slight performance impact.
+
+## Hex Negation
+
+ClamAV supports YARA-compatible hexadecimal byte and nibble negation using the `~` operator (ClamAV 1.6+, functionality level 240). This allows matching any byte *except* a specific value or nibble pattern:
+
+- `~HH`
+
+  Match any byte except `0xHH`. Example: `~00` matches any byte except `0x00`.
+
+- `~H?`
+
+  Match any byte whose high nibble (the four high bits) is not `H`. Example: `~0?` matches any byte where the high nibble is not `0x0`.
+
+- `~?H`
+
+  Match any byte whose low nibble (the four low bits) is not `H`. Example: `~?0` matches any byte where the low nibble is not `0x0`.
+
+### Examples
+
+- `41~0042` matches the sequence `41`, followed by any byte except `0x00`, followed by `42`.
+- `41~?042` matches the sequence `41`, followed by any byte whose low nibble is not `0x0`, followed by `42`.
+- `41~0?42` matches the sequence `41`, followed by any byte whose high nibble is not `0x0`, followed by `42`.
+
+### Invalid Forms
+
+The following forms are not supported and will be rejected:
+
+- `~~00` (double negation)
+- `~??` (negating all bytes)
+- `~` without hex digits
+- `~` applied to character classes or alternates
+- `~[1-2]` (negation combined with gap ranges)
+
+### Minimum Functionality Level Requirement
+
+Databases using hex negation syntax must declare a minimum functionality level of 240. For logical signatures (`.ldb` files), include an `Engine:240` constraint:
+
+```
+MySignature;Target:0;0;41~0042;Engine:240
+```
+
+For native body signatures (`.ndb` files), the parser will enforce the requirement at load time.
+
+### Difference from ClamAV Alternates
+
+Hex negation (`~HH`, `~H?`, and `~?H`) negates exactly one byte or nibble predicate. ClamAV's existing `!(...)` syntax negates a fixed set of alternate byte sequences, which may contain one or multiple bytes:
+
+- `~HH` matches one byte where `byte != 0xHH`
+- `!(aa|bb|cc)` matches one byte that is not in the set `{0xaa, 0xbb, 0xcc}`
+- `!(aaaa|bbbb)` matches a 4-byte sequence that is not in the set `{0xaaaabbbb, 0xbbbbbbbb}`

--- a/src/manual/Signatures/BodySignatureFormat.md
+++ b/src/manual/Signatures/BodySignatureFormat.md
@@ -143,13 +143,25 @@ The following forms are not supported and will be rejected:
 
 ### Minimum Functionality Level Requirement
 
-Databases using hex negation syntax must declare a minimum functionality level of 240. For logical signatures (`.ldb` files), include an `Engine:240` constraint:
+Databases using hex negation syntax must declare a minimum functionality level of 240.
+
+For logical signatures (`.ldb` files), place the `Engine` directive first in the target-description block with a functionality-level range:
 
 ```
-MySignature;Target:0;0;41~0042;Engine:240
+MySignature;Engine:240-255,Target:0;0;41~0042
 ```
 
-For native body signatures (`.ndb` files), the parser will enforce the requirement at load time.
+For extended `.ndb` signatures, use the optional min and max functionality-level fields:
+
+```
+MalwareName:TargetType:Offset:HexSignature[:min_flevel:[max_flevel]]
+```
+
+Example of an extended `.ndb` signature gated to ClamAV 1.6 (FLEVEL 240):
+
+```
+MySignature:0:*:41~0042:240
+```
 
 ### Difference from ClamAV Alternates
 
@@ -157,4 +169,4 @@ Hex negation (`~HH`, `~H?`, and `~?H`) negates exactly one byte or nibble predic
 
 - `~HH` matches one byte where `byte != 0xHH`
 - `!(aa|bb|cc)` matches one byte that is not in the set `{0xaa, 0xbb, 0xcc}`
-- `!(aaaa|bbbb)` matches a 4-byte sequence that is not in the set `{0xaaaabbbb, 0xbbbbbbbb}`
+- `!(aaaa|bbbb)` matches a two-byte sequence that is not `0xaaaa` or `0xbbbb`

--- a/src/manual/Signatures/YaraRules.md
+++ b/src/manual/Signatures/YaraRules.md
@@ -34,4 +34,52 @@ rule CheckFileSize
 }
 ```
 
-This will ensure that the YARA condition always performs the desired action (checking the file size in this example),
+This will ensure that the YARA condition always performs the desired action (checking the file size in this example).
+
+## YARA Hexadecimal String Negation
+
+ClamAV supports YARA 4.3-style hexadecimal byte and nibble negation in hex strings (ClamAV 1.6+, functionality level 240). This allows matching any byte *except* a specific value or nibble pattern within a hex string pattern.
+
+### Supported Forms
+
+- `~HH`: Match any byte except `0xHH`. Example: `{ 41 ~00 42 }` matches `41` followed by any byte except `0x00`, followed by `42`.
+- `~H?`: Match any byte whose high nibble is not `H`. Example: `{ 41 ~0? 42 }` matches `41` followed by any byte where the high nibble is not `0x0`, followed by `42`.
+- `~?H`: Match any byte whose low nibble is not `H`. Example: `{ 41 ~?0 42 }` matches `41` followed by any byte where the low nibble is not `0x0`, followed by `42`.
+
+### Invalid Forms
+
+The following forms are not supported and will be rejected with a parser error:
+
+- `~~00` (double negation)
+- `~??` (negating all bytes)
+- `~` without hex digits
+- `~( AA | BB )` (negation combined with alternates)
+- `~[1-2]` (negation combined with gap ranges)
+- `~` before character classes
+
+### Distinction from YARA Condition Bitwise-NOT
+
+**Important:** YARA hex string negation (`~HH`, `~H?`, `~?H`) is **not** the same as the bitwise-NOT operator (`~`) in YARA conditions:
+- Hex string negation operates inside hex strings and matches one byte with a negated value/pattern predicate.
+- Condition bitwise-NOT (`~ primary_expression`) is an integer operator in YARA condition expressions and performs bitwise negation of condition values.
+
+Example to illustrate the difference:
+
+```perl
+rule HexNegationExample
+{
+  strings:
+    $hex = { 41 ~00 42 }      // Hex string negation: match 41, any byte except 00, and 42
+  condition:
+    $hex
+}
+
+rule ConditionNegationExample
+{
+  strings:
+    $marker = "example"
+
+  condition:
+    $marker and (~1 == -2)    // Condition bitwise-NOT: bitwise negation of integer 1 equals -2
+}
+```


### PR DESCRIPTION
Add documentation for YARA 4.3-compatible hex negation (~HH, ~H?, ~?H) in both native ClamAV signatures and YARA rules. Clarify distinction from bitwise-NOT operator and existing negated alternates.

Relates to PR #1754

CLAM-3047